### PR TITLE
駒フェイズ直後に相手の囲み駒・石を除去するよう修正

### DIFF
--- a/src/after_stone_phase.ts
+++ b/src/after_stone_phase.ts
@@ -2,7 +2,7 @@ import { delete_en_passant_flag, lookup_coords_from_side_and_prof } from "./boar
 import { ShogiColumnName } from "./coordinate";
 import { opponentOf, Side } from "./side";
 import { remove_surrounded } from "./surround";
-import { Board, Entity, GameEnd, ResolvedGameState, StonePhasePlayed, unpromote } from "./type";
+import { Board, Entity, GameEnd, Hand, ResolvedGameState, StonePhasePlayed, unpromote } from "./type";
 
 /** 石フェイズが終了した後、勝敗判定と囲碁検査をする。 / To be called after a stone is placed: checks the victory condition and the game-of-go condition.
  * また、相手のポ兵にアンパッサンフラグがついていたら、それを取り除く（自分が手を指したことによって、アンパッサンの権利が失われたので） 
@@ -109,7 +109,9 @@ function king_is_alive(board: Readonly<Board>, side: Side) {
     return lookup_coords_from_side_and_prof(board, side, "キ").length + lookup_coords_from_side_and_prof(board, side, "超").length > 0;
 }
 
-function remove_surrounded_enitities_from_board_and_add_to_hand_if_necessary(old: StonePhasePlayed, side: Side): void {
+type HasBoardAndHands = { board: Board, hand_of_black: Hand, hand_of_white: Hand };
+
+export function remove_surrounded_enitities_from_board_and_add_to_hand_if_necessary(old: HasBoardAndHands, side: Side): void {
     const black_and_white: (Side | null)[][] = old.board.map(row => row.map(sq => sq === null ? null : sq.side));
     const has_survived = remove_surrounded(side, black_and_white);
 
@@ -122,7 +124,7 @@ function remove_surrounded_enitities_from_board_and_add_to_hand_if_necessary(old
     }));
 }
 
-function send_captured_entity_to_opponent(old: StonePhasePlayed, captured_entity: Entity | null): void {
+function send_captured_entity_to_opponent(old: HasBoardAndHands, captured_entity: Entity | null): void {
     if (!captured_entity) return;
     const opponent = opponentOf(captured_entity.side);
     if (captured_entity.type === "しょ") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { clone_board, get_entity_from_coord, put_entity_at_coord_and_also_adjust
 import { play_piece_phase } from "./piece_phase";
 import { Board, GameEnd, Move, PiecePhasePlayed, ResolvedGameState, StonePhasePlayed } from "./type"
 import { Coordinate, displayCoord } from "./coordinate";
-import { resolve_after_stone_phase } from "./after_stone_phase";
+import { resolve_after_stone_phase, remove_surrounded_enitities_from_board_and_add_to_hand_if_necessary } from "./after_stone_phase";
 import { opponentOf, Side } from "./side";
 import { remove_surrounded } from "./surround";
 
@@ -152,6 +152,10 @@ export function can_place_stone(board: Readonly<Board>, side: Side, stone_to: Co
 
 function one_turn(old: ResolvedGameState, move: Move): ResolvedGameState | GameEnd {
     const after_piece_phase = play_piece_phase(old, move.piece_phase);
+
+    // 公式ルール：駒フェイズの後、すぐに相手の囲まれた駒・石を除去する（自分の駒は除去されない）。
+    // 「石フェイズを指す前に相手の石/駒を囲んで取る」ケースがあるため、石フェイズ前にここで除去しておく。
+    remove_surrounded_enitities_from_board_and_add_to_hand_if_necessary(after_piece_phase, opponentOf(after_piece_phase.by_whom));
 
     const after_stone_phase: StonePhasePlayed = move.stone_to ? place_stone(after_piece_phase, move.piece_phase.side, move.stone_to) : {
         phase: "stone_phase_played",

--- a/src/tests/place_stone.test.ts
+++ b/src/tests/place_stone.test.ts
@@ -1,4 +1,4 @@
-import { main } from ".."
+import { Board, from_custom_state, main, ResolvedGameState } from ".."
 
 test("既に埋まっている", () => {
     expect(() => main([
@@ -10,6 +10,53 @@ test("既に埋まっている", () => {
 test("自殺", () => {
     expect(() => main([
         { "piece_phase": { "side": "黒", "to": ["３", "五"], "prof": "ポ" }, "stone_to": ["４", "二"] },
-        
+
     ])).toThrowError(`黒が４二に碁石を置こうとしていますが、打った瞬間に取られてしまうのでここは着手禁止点です`);
+});
+
+// 公式ルール（shogoss-comprehensive-rules.md §4）：
+// 「駒フェーズの後に，すぐに相手の石・駒の囲みを判定し囲まれていれば除去される」
+// 駒フェイズの着手で相手の石を四方から囲むと、石フェイズが始まる前にその石は取られる。
+// よって、空いたそのマスへ自分の石を打つことは合法。
+test("駒フェイズで相手の石を囲んで取った直後、そのマスに石を置ける", () => {
+    const empty_row = (): null[] => [null, null, null, null, null, null, null, null, null];
+    const board = [
+        empty_row(), empty_row(), empty_row(),
+        empty_row(), empty_row(), empty_row(),
+        empty_row(), empty_row(), empty_row(),
+    ] as unknown as Board;
+
+    // board[行index][列index]。行は一〜九 (0〜8)、列は９〜１ (0〜8)。
+    // ４七 → (行index=6, 列index=5) に白ビ（５六へ一マス斜めで到達できる）
+    board[6]![5] = { type: "ス", side: "白", prof: "ビ", never_moved: false };
+    // ５五 → (4, 4) に黒石（囲まれて取られる対象）
+    board[4]![4] = { type: "碁", side: "黒" };
+    // 残りの三方を白石で埋める
+    board[3]![4] = { type: "碁", side: "白" }; // ５四
+    board[4]![5] = { type: "碁", side: "白" }; // ４五
+    board[4]![3] = { type: "碁", side: "白" }; // ６五
+    // 両キング（除去判定で王が消えないように）
+    board[0]![4] = { type: "王", side: "白", prof: "キ", never_moved: false, has_moved_only_once: false };
+    board[8]![4] = { type: "王", side: "黒", prof: "キ", never_moved: false, has_moved_only_once: false };
+
+    const initial: ResolvedGameState = {
+        phase: "resolved",
+        board,
+        hand_of_black: [],
+        hand_of_white: [],
+        who_goes_next: "白",
+    };
+
+    // 白ビが４七→５六へ斜め移動。着地で５五の黒石は四方を白で囲まれ、
+    // 石フェイズ前に除去される。続いて白が５五に石を打てる。
+    const result = from_custom_state([
+        { piece_phase: { side: "白", to: ["５", "六"], prof: "ビ", from: ["４", "七"] }, stone_to: ["５", "五"] },
+    ], initial);
+
+    expect(result.phase).toBe("resolved");
+    if (result.phase !== "resolved") return;
+
+    expect(result.board[4]![4]).toEqual({ type: "碁", side: "白" });
+    expect(result.board[5]![4]).toEqual({ type: "ス", side: "白", prof: "ビ", never_moved: false });
+    expect(result.who_goes_next).toBe("黒");
 });


### PR DESCRIPTION
// Claude Codeで実装

従来の `one_turn` は `play_piece_phase → place_stone → resolve_after_stone_phase`
  の順で進み、駒フェイズと石フェイズの間に囲み除去が走りません。そのため、駒フェイズの着手で相手の石を四方から囲み、同ターンでそのマスへ自分の石を打つ手順でエラー「`…のマスは既に埋まっています`」が発生していました。

  具体的な再現棋譜（40手目 `△５六ビ５五` で発火）:
```
  ▲７六ナ４四 △６二金５五 ▲５五ナ４六 △１四ナ４二 ▲６八ク５八 △１一キ７五
  ▲９五ポ９七 △２二銀７六 ▲５六ポ８五 △４四ポ２四 ▲３六ナ右６四 △６四ポ３五
  ▲７四ナ１六 △４三ク５二 ▲５五ナ右３六 △３六ビ   ▲７六ナ５五 △４五ポ５四
  ▲５七ナ４八 △６一ナ   ▲１九キ６六 △７二ル７六 ▲９三ナ４四 △８二銀３四
  ▲８一ナ８四 △４六ポ９三 ▲４六ポ２五 △４六ク４三 ▲９三ナ７一 △５七ク９二
  ▲７四ナ２六 △４５ビ９六 ▲８二ナ４六 △４八ク６五 ▲４八金７四 △５六ビ４七
  ▲４七ビ   △６七ビ４五 ▲６一ナ８二 △５六ビ５五
```

  - `src/index.ts` : `one_turn` 内、`play_piece_phase` の直後に「相手の囲まれた駒・石の除去」呼び出しを追加
  - `src/after_stone_phase.ts` : 既存の `remove_surrounded_enitities_from_board_and_add_to_hand_if_necessary` を `export` 化し、受け取り型を `StonePhasePlayed` から構造的部分型 `{ board, hand_of_black,
  hand_of_white }` に緩和（`PiecePhasePlayed` でも呼べるようにするため。ロジックは不変）
  - `src/tests/place_stone.test.ts` : 最小再現の回帰テストを追加